### PR TITLE
Add functionality for custom NBT tags in ItemBuilder

### DIFF
--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/item/ItemBuilder.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/item/ItemBuilder.java
@@ -84,6 +84,18 @@ public class ItemBuilder implements Cloneable {
     }
 
     /**
+     * Adds a custom NBT tag to the item
+     *
+     * @param type  The PersistentDataType
+     * @param key   The key
+     * @param value The value
+     */
+    public <V> ItemBuilder addPersistentValue(PersistentDataType<?, V> type, String key, V value) {
+        NBT.put(key, new Pair<>(type, value));
+        return this;
+    }
+
+    /**
      * Sets the item's material getting it from a String
      *
      * @param material The material


### PR DESCRIPTION
A new method `addPersistentValue` has been added to the ItemBuilder class, allowing for the addition of custom NBT tags to items. This provides more flexibility in item customization.