### PR TITLE
fix: evita NPE in ItemBuilder.build() con placeholder dal valore null

### DIFF
--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/item/ItemBuilder.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/item/ItemBuilder.java
@@ -460,10 +460,13 @@ public class ItemBuilder implements Cloneable {
             this.lore = new ArrayList<>();
         }
 
-        for (String placeholder : placeholders.keySet()) {
-            Object value = placeholders.getOrDefault(placeholder, "NULL");
-            setName(this.name.replace(placeholder, value.toString()));
-            setLore(this.lore.stream().map((s) -> s.replace(placeholder, value.toString()))
+        for (Map.Entry<String, Object> entry : placeholders.entrySet()) {
+            // getOrDefault protegge solo dalla chiave assente: se il valore mappato e' null
+            // va comunque gestito qui, altrimenti value.toString() lancia NPE.
+            Object raw = entry.getValue();
+            String value = raw != null ? raw.toString() : "NULL";
+            setName(this.name.replace(entry.getKey(), value));
+            setLore(this.lore.stream().map((s) -> s.replace(entry.getKey(), value))
                     .collect(Collectors.toList()));
         }
         String name = this.name;


### PR DESCRIPTION
**Problema**

`ItemBuilder.build()` sostituisce i placeholder con:
```java
Object value = placeholders.getOrDefault(placeholder, "NULL");
setName(this.name.replace(placeholder, value.toString()));
```
`getOrDefault` restituisce il default `"NULL"` **solo se la chiave è assente**. Se la chiave è presente ma il valore mappato è `null` (es. `addPlaceHolder("%x", possibileNull)`), `value` è `null` e `value.toString()` lancia un **NullPointerException**.

Riscontrato in produzione da un plugin Novaverse (GUI che passava `OfflinePlayer.getName()` null).

**Fix**

Il loop ora itera su `entrySet()` e sostituisce i valori `null` con il sentinel `"NULL"`, evitando l'NPE (e la doppia lookup key+get). Comportamento retro-compatibile: un placeholder null ora rende `"NULL"` invece di crashare.