### PR TITLE
Fix NPE in ItemBuilder.build() on null placeholder value

### DIFF
--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/item/ItemBuilder.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/item/ItemBuilder.java
@@ -460,10 +460,13 @@ public class ItemBuilder implements Cloneable {
             this.lore = new ArrayList<>();
         }
 
-        for (String placeholder : placeholders.keySet()) {
-            Object value = placeholders.getOrDefault(placeholder, "NULL");
-            setName(this.name.replace(placeholder, value.toString()));
-            setLore(this.lore.stream().map((s) -> s.replace(placeholder, value.toString()))
+        for (Map.Entry<String, Object> entry : placeholders.entrySet()) {
+            // getOrDefault only guards the absent-key case: a key mapped to a null value
+            // must still be handled here, otherwise value.toString() would throw an NPE.
+            Object raw = entry.getValue();
+            String value = raw != null ? raw.toString() : "NULL";
+            setName(this.name.replace(entry.getKey(), value));
+            setLore(this.lore.stream().map((s) -> s.replace(entry.getKey(), value))
                     .collect(Collectors.toList()));
         }
         String name = this.name;

--- a/tests/src/test/java/it/mycraft/powerlib/bukkit/item/ItemBuilderTest.java
+++ b/tests/src/test/java/it/mycraft/powerlib/bukkit/item/ItemBuilderTest.java
@@ -244,4 +244,20 @@ class ItemBuilderTest {
         assertThat(first.getType()).isEqualTo(second.getType());
         assertThat(second.getItemMeta().getDisplayName()).isEqualTo("Repeat");
     }
+
+    @Test
+    void nullPlaceholderValueRendersAsSentinelWithoutThrowing() {
+        // Regression: a placeholder key present with a null value (e.g. OfflinePlayer#getName())
+        // used to NPE in build(), because getOrDefault only guards the absent-key case.
+        ItemStack stack = new ItemBuilder()
+                .setMaterial(Material.PAPER)
+                .setName("Owner: %owner%")
+                .setLore("Holder: %owner%")
+                .addPlaceHolder("%owner%", null)
+                .build();
+
+        ItemMeta meta = stack.getItemMeta();
+        assertThat(meta.getDisplayName()).isEqualTo("Owner: NULL");
+        assertThat(meta.getLore()).containsExactly("Holder: NULL");
+    }
 }


### PR DESCRIPTION
Supersedes #19 (rebased without the AI co-author trailer, plus a regression test).

The placeholder loop used `getOrDefault(key, "NULL")`, which only guards the absent-key case: a key present with a null value returned null and `value.toString()` threw. Now iterates `entrySet()` and falls back to the "NULL" sentinel for null values (also drops the redundant key+get lookup). Original fix by @antoilmalvagio; added a MockBukkit regression test that reproduces the NPE. Full `tests` module green locally (24 ItemBuilder tests).