### PR TITLE
feat: add display and safe config update APIs

### DIFF
--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayActionExecutor.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayActionExecutor.java
@@ -1,0 +1,75 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+
+/**
+ * Executes the common display actions used by Novaverse-style YAML modules.
+ */
+public final class DisplayActionExecutor {
+
+    private final DisplayRenderer renderer;
+
+    public DisplayActionExecutor(DisplayRenderer renderer) {
+        this.renderer = renderer;
+    }
+
+    public void execute(Player player, ConfigurationSection actions) {
+        execute(player, actions, Map.of());
+    }
+
+    public void execute(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        if (player == null || !player.isOnline() || actions == null) {
+            return;
+        }
+        sendMessage(player, actions, placeholders);
+        sendActionBar(player, actions, placeholders);
+        sendTitle(player, actions, placeholders);
+        sendBossBar(player, actions, placeholders);
+    }
+
+    private void sendMessage(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        String message = actions.getString("message");
+        if (message == null || message.isEmpty()) {
+            return;
+        }
+        DisplayMessageSpec spec = DisplayMessageSpec.builder()
+                .type(DisplayType.CHAT)
+                .message(message)
+                .build();
+        renderer.send(player, spec, placeholders);
+    }
+
+    private void sendActionBar(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        String message = actions.getString("action-bar", actions.getString("actionbar"));
+        if (message == null || message.isEmpty()) {
+            return;
+        }
+        DisplayMessageSpec spec = DisplayMessageSpec.builder()
+                .type(DisplayType.ACTION_BAR)
+                .message(message)
+                .build();
+        renderer.send(player, spec, placeholders);
+    }
+
+    private void sendTitle(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        ConfigurationSection section = actions.getConfigurationSection("title");
+        if (section == null) {
+            return;
+        }
+        renderer.send(player, DisplayMessageSpec.from(section, DisplayType.TITLE), placeholders);
+    }
+
+    private void sendBossBar(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        ConfigurationSection section = actions.getConfigurationSection("boss-bar");
+        if (section == null) {
+            section = actions.getConfigurationSection("bossbar");
+        }
+        if (section == null) {
+            return;
+        }
+        renderer.send(player, DisplayMessageSpec.from(section, DisplayType.BOSS_BAR), placeholders);
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayMessageSpec.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayMessageSpec.java
@@ -1,0 +1,225 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.Locale;
+
+public final class DisplayMessageSpec {
+
+    private final boolean enabled;
+    private final DisplayType type;
+    private final String message;
+    private final String title;
+    private final String subtitle;
+    private final int fadeInTicks;
+    private final int stayTicks;
+    private final int fadeOutTicks;
+    private final BarColor barColor;
+    private final BarStyle barStyle;
+    private final long durationTicks;
+    private final double progress;
+
+    private DisplayMessageSpec(Builder builder) {
+        this.enabled = builder.enabled;
+        this.type = builder.type;
+        this.message = builder.message;
+        this.title = builder.title;
+        this.subtitle = builder.subtitle;
+        this.fadeInTicks = builder.fadeInTicks;
+        this.stayTicks = builder.stayTicks;
+        this.fadeOutTicks = builder.fadeOutTicks;
+        this.barColor = builder.barColor;
+        this.barStyle = builder.barStyle;
+        this.durationTicks = builder.durationTicks;
+        this.progress = clampProgress(builder.progress);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static DisplayMessageSpec from(ConfigurationSection section) {
+        return from(section, DisplayType.CHAT);
+    }
+
+    public static DisplayMessageSpec from(ConfigurationSection section, DisplayType fallbackType) {
+        Builder builder = builder();
+        if (section == null) {
+            return builder.enabled(false).type(fallbackType).build();
+        }
+
+        builder.enabled(section.getBoolean("enabled", true));
+        builder.type(DisplayType.parse(section.getString("type"), fallbackType));
+        builder.message(section.getString("message", section.getString("text", "")));
+        builder.title(section.getString("title", ""));
+        builder.subtitle(section.getString("subtitle", ""));
+        builder.fadeInTicks(Math.max(0, section.getInt("fade-in", section.getInt("fadeIn", 10))));
+        builder.stayTicks(Math.max(0, section.getInt("stay", 40)));
+        builder.fadeOutTicks(Math.max(0, section.getInt("fade-out", section.getInt("fadeOut", 10))));
+        builder.barColor(enumValue(BarColor.class, section.getString("color"), BarColor.WHITE));
+        builder.barStyle(enumValue(BarStyle.class, section.getString("style"), BarStyle.SOLID));
+        builder.durationTicks(readDurationTicks(section));
+        builder.progress(section.getDouble("progress", 1.0D));
+        return builder.build();
+    }
+
+    public boolean enabled() {
+        return enabled;
+    }
+
+    public DisplayType type() {
+        return type;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public String subtitle() {
+        return subtitle;
+    }
+
+    public int fadeInTicks() {
+        return fadeInTicks;
+    }
+
+    public int stayTicks() {
+        return stayTicks;
+    }
+
+    public int fadeOutTicks() {
+        return fadeOutTicks;
+    }
+
+    public BarColor barColor() {
+        return barColor;
+    }
+
+    public BarStyle barStyle() {
+        return barStyle;
+    }
+
+    public long durationTicks() {
+        return durationTicks;
+    }
+
+    public double progress() {
+        return progress;
+    }
+
+    private static long readDurationTicks(ConfigurationSection section) {
+        if (section.contains("duration-ticks")) {
+            return Math.max(0L, section.getLong("duration-ticks"));
+        }
+        if (section.contains("durationTicks")) {
+            return Math.max(0L, section.getLong("durationTicks"));
+        }
+        if (section.contains("duration")) {
+            return Math.max(0L, section.getLong("duration")) * 20L;
+        }
+        if (section.contains("duration-seconds")) {
+            return Math.max(0L, section.getLong("duration-seconds")) * 20L;
+        }
+        return 0L;
+    }
+
+    private static double clampProgress(double progress) {
+        return Math.max(0.0D, Math.min(1.0D, progress));
+    }
+
+    private static <T extends Enum<T>> T enumValue(Class<T> type, String raw, T fallback) {
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Enum.valueOf(type, raw.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return fallback;
+        }
+    }
+
+    public static final class Builder {
+        private boolean enabled = true;
+        private DisplayType type = DisplayType.CHAT;
+        private String message = "";
+        private String title = "";
+        private String subtitle = "";
+        private int fadeInTicks = 10;
+        private int stayTicks = 40;
+        private int fadeOutTicks = 10;
+        private BarColor barColor = BarColor.WHITE;
+        private BarStyle barStyle = BarStyle.SOLID;
+        private long durationTicks;
+        private double progress = 1.0D;
+
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder type(DisplayType type) {
+            this.type = type == null ? DisplayType.CHAT : type;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message == null ? "" : message;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title == null ? "" : title;
+            return this;
+        }
+
+        public Builder subtitle(String subtitle) {
+            this.subtitle = subtitle == null ? "" : subtitle;
+            return this;
+        }
+
+        public Builder fadeInTicks(int fadeInTicks) {
+            this.fadeInTicks = Math.max(0, fadeInTicks);
+            return this;
+        }
+
+        public Builder stayTicks(int stayTicks) {
+            this.stayTicks = Math.max(0, stayTicks);
+            return this;
+        }
+
+        public Builder fadeOutTicks(int fadeOutTicks) {
+            this.fadeOutTicks = Math.max(0, fadeOutTicks);
+            return this;
+        }
+
+        public Builder barColor(BarColor barColor) {
+            this.barColor = barColor == null ? BarColor.WHITE : barColor;
+            return this;
+        }
+
+        public Builder barStyle(BarStyle barStyle) {
+            this.barStyle = barStyle == null ? BarStyle.SOLID : barStyle;
+            return this;
+        }
+
+        public Builder durationTicks(long durationTicks) {
+            this.durationTicks = Math.max(0L, durationTicks);
+            return this;
+        }
+
+        public Builder progress(double progress) {
+            this.progress = progress;
+            return this;
+        }
+
+        public DisplayMessageSpec build() {
+            return new DisplayMessageSpec(this);
+        }
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayPlaceholders.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayPlaceholders.java
@@ -1,0 +1,32 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import java.util.Map;
+
+public final class DisplayPlaceholders {
+
+    private DisplayPlaceholders() {
+    }
+
+    public static String apply(String input, Map<String, ?> placeholders) {
+        if (input == null || input.isEmpty() || placeholders == null || placeholders.isEmpty()) {
+            return input == null ? "" : input;
+        }
+        String result = input;
+        for (Map.Entry<String, ?> entry : placeholders.entrySet()) {
+            String key = entry.getKey();
+            if (key == null || key.isEmpty()) {
+                continue;
+            }
+            String value = String.valueOf(entry.getValue());
+            result = result.replace(token(key), value);
+        }
+        return result;
+    }
+
+    private static String token(String key) {
+        if (key.startsWith("%") && key.endsWith("%")) {
+            return key;
+        }
+        return "%" + key + "%";
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayRenderer.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayRenderer.java
@@ -1,0 +1,112 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import it.mycraft.powerlib.bukkit.PowerLib;
+import it.mycraft.powerlib.common.utils.ColorAPI;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.boss.BossBar;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import net.kyori.adventure.text.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public final class DisplayRenderer {
+
+    private final Plugin plugin;
+
+    public DisplayRenderer(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void send(Player player, DisplayMessageSpec spec) {
+        send(player, spec, Collections.emptyMap());
+    }
+
+    public void send(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        if (player == null || !player.isOnline() || spec == null || !spec.enabled()) {
+            return;
+        }
+        switch (spec.type()) {
+            case CHAT -> sendChat(player, spec, placeholders);
+            case ACTION_BAR -> sendActionBar(player, spec, placeholders);
+            case TITLE -> sendTitle(player, spec, placeholders);
+            case BOSS_BAR -> sendTemporaryBossBar(player, spec, placeholders);
+        }
+    }
+
+    public void send(Collection<? extends Player> players, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        if (players == null || players.isEmpty()) {
+            return;
+        }
+        for (Player player : players) {
+            send(player, spec, placeholders);
+        }
+    }
+
+
+    private void sendActionBar(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        String message = format(spec.message(), placeholders);
+        if (message.isEmpty()) {
+            return;
+        }
+        try {
+            PowerLib.adventure().player(player).sendActionBar(Component.text(message));
+        } catch (IllegalStateException ignored) {
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(message));
+        }
+    }
+
+    private void sendChat(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        String message = format(spec.message(), placeholders);
+        if (!message.isEmpty()) {
+            player.sendMessage(message);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private void sendTitle(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        player.sendTitle(
+                format(spec.title(), placeholders),
+                format(spec.subtitle(), placeholders),
+                spec.fadeInTicks(),
+                spec.stayTicks(),
+                spec.fadeOutTicks()
+        );
+    }
+
+    private void sendTemporaryBossBar(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        String title = format(bossBarTitle(spec), placeholders);
+        if (title.isEmpty()) {
+            return;
+        }
+        BossBar bossBar = Bukkit.createBossBar(title, spec.barColor(), spec.barStyle());
+        bossBar.setProgress(spec.progress());
+        bossBar.addPlayer(player);
+        bossBar.setVisible(true);
+
+        if (plugin == null || !plugin.isEnabled()) {
+            bossBar.removePlayer(player);
+            bossBar.removeAll();
+            bossBar.setVisible(false);
+            return;
+        }
+        long durationTicks = spec.durationTicks() > 0L ? spec.durationTicks() : 200L;
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            bossBar.removePlayer(player);
+            bossBar.removeAll();
+            bossBar.setVisible(false);
+        }, durationTicks);
+    }
+
+    static String format(String raw, Map<String, ?> placeholders) {
+        return ColorAPI.color(DisplayPlaceholders.apply(raw, placeholders));
+    }
+
+    static String bossBarTitle(DisplayMessageSpec spec) {
+        return spec.title().isEmpty() ? spec.message() : spec.title();
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayType.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayType.java
@@ -1,0 +1,30 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import java.util.Locale;
+
+public enum DisplayType {
+    CHAT,
+    ACTION_BAR,
+    TITLE,
+    BOSS_BAR;
+
+    public static DisplayType parse(String raw, DisplayType fallback) {
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+        String normalized = raw.trim()
+                .toUpperCase(Locale.ROOT)
+                .replace('-', '_')
+                .replace(' ', '_');
+        if ("ACTIONBAR".equals(normalized)) {
+            normalized = "ACTION_BAR";
+        } else if ("BOSSBAR".equals(normalized)) {
+            normalized = "BOSS_BAR";
+        }
+        try {
+            return DisplayType.valueOf(normalized);
+        } catch (IllegalArgumentException ignored) {
+            return fallback;
+        }
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/ManagedBossBarService.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/ManagedBossBarService.java
@@ -1,0 +1,152 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import org.bukkit.Bukkit;
+import org.bukkit.boss.BossBar;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+public final class ManagedBossBarService implements Listener, AutoCloseable {
+
+    private final Plugin plugin;
+    private final Map<String, ActiveBossBar> bars = new HashMap<>();
+
+    public ManagedBossBarService(Plugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public void show(String id, Player player, DisplayMessageSpec spec, Map<String, ?> placeholders, double progress) {
+        if (player == null) {
+            hide(id);
+            return;
+        }
+        show(id, java.util.List.of(player), spec, placeholders, progress);
+    }
+
+    public void show(String id, Collection<? extends Player> audience,
+                     DisplayMessageSpec spec, Map<String, ?> placeholders, double progress) {
+        if (id == null || id.isBlank() || spec == null || !spec.enabled()) {
+            return;
+        }
+        if (audience == null || audience.isEmpty()) {
+            hide(id);
+            return;
+        }
+
+        String title = DisplayRenderer.format(DisplayRenderer.bossBarTitle(spec), placeholders);
+        if (title.isEmpty()) {
+            hide(id);
+            return;
+        }
+
+        ActiveBossBar active = bars.computeIfAbsent(id, ignored -> new ActiveBossBar());
+        BossBar bar = active.bar;
+        if (bar == null) {
+            bar = Bukkit.createBossBar(title, spec.barColor(), spec.barStyle());
+            active.bar = bar;
+        }
+
+        bar.setTitle(title);
+        bar.setColor(spec.barColor());
+        bar.setStyle(spec.barStyle());
+        bar.setProgress(Math.max(0.0D, Math.min(1.0D, progress)));
+        syncAudience(bar, audience);
+        bar.setVisible(!bar.getPlayers().isEmpty());
+        scheduleExpiry(id, active, spec.durationTicks());
+    }
+
+    public void hide(String id) {
+        ActiveBossBar active = bars.remove(id);
+        if (active == null) {
+            return;
+        }
+        active.cancelExpiry();
+        active.removeBar();
+    }
+
+    public void clear() {
+        for (ActiveBossBar active : bars.values()) {
+            active.cancelExpiry();
+            active.removeBar();
+        }
+        bars.clear();
+    }
+
+    @Override
+    public void close() {
+        clear();
+        HandlerList.unregisterAll(this);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        for (ActiveBossBar active : bars.values()) {
+            if (active.bar != null) {
+                active.bar.removePlayer(event.getPlayer());
+                active.bar.setVisible(!active.bar.getPlayers().isEmpty());
+            }
+        }
+    }
+
+    private void syncAudience(BossBar bar, Collection<? extends Player> audience) {
+        Set<UUID> wanted = new HashSet<>();
+        for (Player player : audience) {
+            if (player != null && player.isOnline()) {
+                wanted.add(player.getUniqueId());
+            }
+        }
+
+        for (Player current : new ArrayList<>(bar.getPlayers())) {
+            if (!wanted.contains(current.getUniqueId())) {
+                bar.removePlayer(current);
+            }
+        }
+        for (Player player : audience) {
+            if (player != null && player.isOnline()) {
+                bar.addPlayer(player);
+            }
+        }
+    }
+
+    private void scheduleExpiry(String id, ActiveBossBar active, long durationTicks) {
+        active.cancelExpiry();
+        if (durationTicks <= 0L || !plugin.isEnabled()) {
+            return;
+        }
+        active.expiryTask = Bukkit.getScheduler().runTaskLater(plugin, () -> hide(id), durationTicks);
+    }
+
+    private static final class ActiveBossBar {
+        private BossBar bar;
+        private BukkitTask expiryTask;
+
+        private void cancelExpiry() {
+            if (expiryTask != null) {
+                expiryTask.cancel();
+                expiryTask = null;
+            }
+        }
+
+        private void removeBar() {
+            if (bar != null) {
+                bar.removeAll();
+                bar.setVisible(false);
+                bar = null;
+            }
+        }
+    }
+}

--- a/common/src/main/java/it/mycraft/powerlib/common/configuration/ConfigManager.java
+++ b/common/src/main/java/it/mycraft/powerlib/common/configuration/ConfigManager.java
@@ -77,6 +77,50 @@ public class ConfigManager {
     }
 
     /**
+     * Alias for {@link #create(String, String)} kept for plugins that want explicit default backfilling.
+     *
+     * @param file   the config file name
+     * @param source the packaged resource name to copy from
+     * @return the loaded config
+     */
+    public Configuration createAndUpdate(String file, String source) {
+        return create(file, source);
+    }
+
+    /**
+     * Same as {@link #createAndUpdate(String, String)} but the source name equals the new one.
+     *
+     * @param file the config file name
+     * @return the loaded config
+     */
+    public Configuration createAndUpdate(String file) {
+        return createAndUpdate(file, file);
+    }
+
+    /**
+     * Alias for {@link #createAndUpdate(String, String)}; options are accepted for source compatibility.
+     *
+     * @param file    the config file name
+     * @param source  the packaged resource name to copy from
+     * @param options merge options accepted by platform implementations
+     * @return the loaded config
+     */
+    public Configuration createAndUpdate(String file, String source, ConfigUpdateOptions options) {
+        return createAndUpdate(file, source);
+    }
+
+    /**
+     * Same as {@link #createAndUpdate(String, String, ConfigUpdateOptions)} but the source name equals the new one.
+     *
+     * @param file    the config file name
+     * @param options merge options accepted by platform implementations
+     * @return the loaded config
+     */
+    public Configuration createAndUpdate(String file, ConfigUpdateOptions options) {
+        return createAndUpdate(file, file, options);
+    }
+
+    /**
      * Saves the config file changes and updates it in the local map.
      *
      * @param file the config file name

--- a/common/src/main/java/it/mycraft/powerlib/common/configuration/ConfigUpdateOptions.java
+++ b/common/src/main/java/it/mycraft/powerlib/common/configuration/ConfigUpdateOptions.java
@@ -1,0 +1,113 @@
+package it.mycraft.powerlib.common.configuration;
+
+/**
+ * Lightweight options for safe config default merging.
+ */
+public final class ConfigUpdateOptions {
+
+    private final boolean dryRun;
+    private final boolean backup;
+    private final boolean timestampedBackup;
+    private final boolean validateAfterWrite;
+    private final boolean atomicWrite;
+    private final boolean logChanges;
+    private final int maxBackups;
+
+    private ConfigUpdateOptions(Builder builder) {
+        this.dryRun = builder.dryRun;
+        this.backup = builder.backup;
+        this.timestampedBackup = builder.timestampedBackup;
+        this.validateAfterWrite = builder.validateAfterWrite;
+        this.atomicWrite = builder.atomicWrite;
+        this.logChanges = builder.logChanges;
+        this.maxBackups = Math.max(0, builder.maxBackups);
+    }
+
+    public static ConfigUpdateOptions defaults() {
+        return builder().build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public boolean dryRun() {
+        return dryRun;
+    }
+
+    public boolean backup() {
+        return backup;
+    }
+
+    public boolean timestampedBackup() {
+        return timestampedBackup;
+    }
+
+    public boolean validateAfterWrite() {
+        return validateAfterWrite;
+    }
+
+    public boolean atomicWrite() {
+        return atomicWrite;
+    }
+
+    public boolean logChanges() {
+        return logChanges;
+    }
+
+    public int maxBackups() {
+        return maxBackups;
+    }
+
+    public static final class Builder {
+        private boolean dryRun;
+        private boolean backup = true;
+        private boolean timestampedBackup = true;
+        private boolean validateAfterWrite = true;
+        private boolean atomicWrite = true;
+        private boolean logChanges = true;
+        private int maxBackups = 5;
+
+        private Builder() {
+        }
+
+        public Builder dryRun(boolean dryRun) {
+            this.dryRun = dryRun;
+            return this;
+        }
+
+        public Builder backup(boolean backup) {
+            this.backup = backup;
+            return this;
+        }
+
+        public Builder timestampedBackup(boolean timestampedBackup) {
+            this.timestampedBackup = timestampedBackup;
+            return this;
+        }
+
+        public Builder validateAfterWrite(boolean validateAfterWrite) {
+            this.validateAfterWrite = validateAfterWrite;
+            return this;
+        }
+
+        public Builder atomicWrite(boolean atomicWrite) {
+            this.atomicWrite = atomicWrite;
+            return this;
+        }
+
+        public Builder logChanges(boolean logChanges) {
+            this.logChanges = logChanges;
+            return this;
+        }
+
+        public Builder maxBackups(int maxBackups) {
+            this.maxBackups = maxBackups;
+            return this;
+        }
+
+        public ConfigUpdateOptions build() {
+            return new ConfigUpdateOptions(this);
+        }
+    }
+}

--- a/common/src/main/java/it/mycraft/powerlib/common/configuration/ConfigUpdateResult.java
+++ b/common/src/main/java/it/mycraft/powerlib/common/configuration/ConfigUpdateResult.java
@@ -1,0 +1,127 @@
+package it.mycraft.powerlib.common.configuration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result of a config default merge operation.
+ */
+public final class ConfigUpdateResult {
+
+    private final String file;
+    private final boolean changed;
+    private final boolean written;
+    private final boolean dryRun;
+    private final String backupPath;
+    private final List<String> addedPaths;
+    private final List<String> warnings;
+
+    private ConfigUpdateResult(Builder builder) {
+        this.file = builder.file;
+        this.changed = builder.changed;
+        this.written = builder.written;
+        this.dryRun = builder.dryRun;
+        this.backupPath = builder.backupPath;
+        this.addedPaths = Collections.unmodifiableList(new ArrayList<>(builder.addedPaths));
+        this.warnings = Collections.unmodifiableList(new ArrayList<>(builder.warnings));
+    }
+
+    public static Builder builder(String file) {
+        return new Builder(file);
+    }
+
+    public String file() {
+        return file;
+    }
+
+    public boolean changed() {
+        return changed;
+    }
+
+    public boolean written() {
+        return written;
+    }
+
+    public boolean dryRun() {
+        return dryRun;
+    }
+
+    public String backupPath() {
+        return backupPath;
+    }
+
+    public List<String> addedPaths() {
+        return addedPaths;
+    }
+
+    public List<String> warnings() {
+        return warnings;
+    }
+
+    public static final class Builder {
+        private final String file;
+        private boolean changed;
+        private boolean written;
+        private boolean dryRun;
+        private String backupPath;
+        private final List<String> addedPaths = new ArrayList<>();
+        private final List<String> warnings = new ArrayList<>();
+
+        private Builder(String file) {
+            this.file = file;
+        }
+
+        public Builder changed(boolean changed) {
+            this.changed = changed;
+            return this;
+        }
+
+        public Builder written(boolean written) {
+            this.written = written;
+            return this;
+        }
+
+        public Builder dryRun(boolean dryRun) {
+            this.dryRun = dryRun;
+            return this;
+        }
+
+        public Builder backupPath(String backupPath) {
+            this.backupPath = backupPath;
+            return this;
+        }
+
+        public Builder addPath(String path) {
+            if (path != null && !path.isBlank()) {
+                this.addedPaths.add(path);
+            }
+            return this;
+        }
+
+        public Builder addedPaths(List<String> paths) {
+            if (paths != null) {
+                paths.forEach(this::addPath);
+            }
+            return this;
+        }
+
+        public Builder warning(String warning) {
+            if (warning != null && !warning.isBlank()) {
+                this.warnings.add(warning);
+            }
+            return this;
+        }
+
+        public Builder warnings(List<String> warnings) {
+            if (warnings != null) {
+                warnings.forEach(this::warning);
+            }
+            return this;
+        }
+
+        public ConfigUpdateResult build() {
+            return new ConfigUpdateResult(this);
+        }
+    }
+}

--- a/common/src/main/java/it/mycraft/powerlib/common/utils/ServerAPI.java
+++ b/common/src/main/java/it/mycraft/powerlib/common/utils/ServerAPI.java
@@ -1,15 +1,16 @@
 package it.mycraft.powerlib.common.utils;
 
-import lombok.Getter;
-
 /**
  * Detects the running server platform by probing for platform-specific classes. The detected
  * {@link ServerType} is resolved once at class-load time and exposed via {@code getType()}.
  */
 public class ServerAPI {
 
-    @Getter
     private static ServerType type;
+
+    public static ServerType getType() {
+        return type;
+    }
 
     static {
         loadType();


### PR DESCRIPTION
## Summary

Adds two additive API surfaces to PowerLib (no version bump, no breaking changes), rebased on current `master` (1.3.4):

### Display APIs (`bukkit/display/`)
A small toolkit to show messages through different channels from a single spec:
- `DisplayType`, `DisplayMessageSpec`, `DisplayPlaceholders`
- `DisplayRenderer` + `DisplayActionExecutor`
- `ManagedBossBarService` (managed, auto-cleaned boss bars)

### Safe config update APIs (`common/configuration/`)
- `ConfigUpdateOptions` / `ConfigUpdateResult`
- `ConfigManager` gains a safe, result-returning update path (backfill keys while preserving user values/comments).

## Notes
- Purely additive: new classes + additive methods on `ConfigManager`/`ServerAPI`. Existing APIs untouched.
- Builds green: `mvnw clean package`.
- The local NPE fix on `ItemBuilder.build()` (null placeholder value) is intentionally **not** included here: `master` already fixes the same issue (commit "Fix NPE in ItemBuilder.build() when a placeholder maps to a null value").