### PR TITLE
Add NexoFurnitureBreakEvent to the Nexo bridge

### DIFF
--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/events/NexoFurnitureBreakEvent.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/events/NexoFurnitureBreakEvent.java
@@ -1,0 +1,55 @@
+package it.mycraft.powerlib.bukkit.events;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Fired when a player breaks a Nexo furniture or custom block. Carries the Nexo id (and the raw
+ * Nexo mechanic as an {@code Object}) so downstream plugins can react without a direct Nexo dependency.
+ *
+ * <p>Counterpart of {@link NexoFurnitureInteractEvent}: plugins that keep per-furniture state keyed by
+ * location need a break signal to release that state when the furniture goes away.
+ */
+@Getter
+public class NexoFurnitureBreakEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player player;
+    private final String furnitureId;
+    private final Object nexoFurniture;
+
+    @Setter
+    private boolean cancelled;
+
+    /**
+     * Creates the event.
+     *
+     * @param player        the player who broke the furniture or custom block
+     * @param furnitureId   the Nexo id of the furniture or custom block
+     * @param nexoFurniture the raw Nexo mechanic object
+     */
+    public NexoFurnitureBreakEvent(Player player, String furnitureId, Object nexoFurniture) {
+        this.player = player;
+        this.furnitureId = furnitureId;
+        this.nexoFurniture = nexoFurniture;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    /**
+     * Returns the handler list for this event type, as required by the Bukkit event system.
+     *
+     * @return the shared handler list
+     */
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/listeners/NexoListener.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/listeners/NexoListener.java
@@ -1,23 +1,27 @@
 package it.mycraft.powerlib.bukkit.listeners;
 
+import it.mycraft.powerlib.bukkit.events.NexoFurnitureBreakEvent;
 import it.mycraft.powerlib.bukkit.events.NexoFurnitureInteractEvent;
 import it.mycraft.powerlib.bukkit.utils.NexoUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.plugin.Plugin;
 
 /**
- * Detects right-click interactions with Nexo furniture / custom blocks (via {@link NexoUtils}) and
- * re-fires them as a dependency-free {@link NexoFurnitureInteractEvent}. Registered only when Nexo is
- * present, via {@link #register(Plugin)}.
+ * Detects interactions with Nexo furniture / custom blocks (via {@link NexoUtils}) and re-fires them as
+ * dependency-free {@link NexoFurnitureInteractEvent} / {@link NexoFurnitureBreakEvent}. Registered only
+ * when Nexo is present, via {@link #register(Plugin)}.
  */
 public final class NexoListener implements Listener {
 
@@ -65,11 +69,48 @@ public final class NexoListener implements Listener {
         fire(event.getPlayer(), NexoUtils.getNexoId(event.getRightClicked()), event.getRightClicked(), event);
     }
 
+    /**
+     * Re-fires the breaking of a Nexo custom block (or a furniture's barrier hitbox) as a
+     * {@link NexoFurnitureBreakEvent}.
+     *
+     * @param event the originating block break event
+     */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onBlockBreak(BlockBreakEvent event) {
+        fireBreak(event.getPlayer(), NexoUtils.getNexoId(event.getBlock()), event.getBlock(), event);
+    }
+
+    /**
+     * Re-fires a player breaking a Nexo furniture entity as a {@link NexoFurnitureBreakEvent}. Furniture
+     * is removed by damaging its entity, so the player's hit is the break signal.
+     *
+     * @param event the originating damage event
+     */
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onEntityBreak(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player player)) {
+            return;
+        }
+        Entity furniture = event.getEntity();
+        fireBreak(player, NexoUtils.getNexoId(furniture), furniture, event);
+    }
+
     private void fire(Player player, String furnitureId, Object nexoFurniture, Cancellable source) {
         if (furnitureId == null || furnitureId.isEmpty()) {
             return;
         }
         NexoFurnitureInteractEvent event = new NexoFurnitureInteractEvent(player, furnitureId, nexoFurniture);
+        Bukkit.getPluginManager().callEvent(event);
+        if (event.isCancelled()) {
+            source.setCancelled(true);
+        }
+    }
+
+    private void fireBreak(Player player, String furnitureId, Object nexoFurniture, Cancellable source) {
+        if (furnitureId == null || furnitureId.isEmpty()) {
+            return;
+        }
+        NexoFurnitureBreakEvent event = new NexoFurnitureBreakEvent(player, furnitureId, nexoFurniture);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
             source.setCancelled(true);


### PR DESCRIPTION
## Problem

`NexoListener` already re-fires right-clicks on Nexo furniture / custom blocks as a dependency-free `NexoFurnitureInteractEvent`, but there is no **break** counterpart.

Plugins that keep per-furniture state keyed by location (e.g. an open/closed door, a running crafting station) have no signal to release that state when the furniture is destroyed, so the entries leak and a newly placed furniture at the same spot inherits stale state.

## Change

- Add `NexoFurnitureBreakEvent`, mirroring `NexoFurnitureInteractEvent` exactly: `player`, `furnitureId`, raw `nexoFurniture` mechanic (`Block` or `Entity`), `Cancellable`.
- Fire it from `NexoListener`:
  - `BlockBreakEvent` -> Nexo custom blocks and furniture barrier hitboxes;
  - `EntityDamageByEntityEvent` (damager is a `Player`) -> furniture entities, which are removed by damaging them.
- Cancelling the event cancels the originating Bukkit event, consistent with the interact bridge.

No new dependency: it goes through the existing `NexoUtils` reflection bridge, so PowerLib stays on Java 17 and the listener stays inert when Nexo is absent.

## Verification

`./mvnw -pl bukkit -am compile` green.