### PR TITLE
fix: keep nexo: materials and player-head owners in ItemBuilder

### DIFF
--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/item/ItemBuilder.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/item/ItemBuilder.java
@@ -114,7 +114,7 @@ public class ItemBuilder implements Cloneable {
      * @return The ItemBuilder
      */
     public ItemBuilder setMaterial(String material) {
-        if (material.length() > 11 && !material.startsWith("itemsadder:")) {
+        if (material.length() > 11 && !material.startsWith("itemsadder:") && !material.startsWith("nexo:")) {
             Optional<Material> optMaterial = Enums.getIfPresent(Material.class, material).toJavaUtil();
             if (optMaterial.isPresent())
                 this.material = optMaterial.get().toString();
@@ -531,6 +531,13 @@ public class ItemBuilder implements Cloneable {
 
             if (customModelData != 0) {
                 itemMeta.setCustomModelData(customModelData);
+            }
+
+            // A skull owner set via setPlayerHead survives only if the final material really is a head:
+            // a later setMaterial() may have moved this builder off PLAYER_HEAD, in which case the owner
+            // is simply dropped.
+            if (skullMeta != null && itemMeta instanceof SkullMeta skull) {
+                skull.setOwningPlayer(skullMeta.getOwningPlayer());
             }
 
             for (Map.Entry<NamespacedKey, Pair<PersistentDataType, Object>> entry : persistentData.entrySet()) {

--- a/tests/src/test/java/it/mycraft/powerlib/bukkit/item/ItemBuilderTest.java
+++ b/tests/src/test/java/it/mycraft/powerlib/bukkit/item/ItemBuilderTest.java
@@ -3,11 +3,13 @@ package it.mycraft.powerlib.bukkit.item;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,6 +78,32 @@ class ItemBuilderTest {
     void setMaterialFromInvalidStringFallsBackToStone() {
         ItemStack stack = new ItemBuilder().setMaterial("NOT_A_REAL_MATERIAL_NAME").build();
         assertThat(stack.getType()).isEqualTo(Material.STONE);
+    }
+
+    @Test
+    void nexoMaterialStringIsKeptVerbatimAndResolvedAtBuildTime() {
+        // Regression: "nexo:<id>" is longer than 11 chars and is not a Material constant, so the
+        // enum-normalisation branch used to drop it and build() fell back to STONE. The prefix must
+        // survive setMaterial and reach build(), which (with Nexo absent here) yields the BARRIER
+        // fallback rather than a silent stone.
+        ItemBuilder builder = new ItemBuilder().setMaterial("nexo:badge_card");
+        assertThat(builder.getMaterial()).isEqualTo("nexo:badge_card");
+        assertThat(builder.build().getType()).isEqualTo(Material.BARRIER);
+    }
+
+    @Test
+    void playerHeadKeepsItsOwner() {
+        // Regression: setPlayerHead stored the owner on an internal SkullMeta that build() never
+        // read, so every head came out ownerless.
+        OfflinePlayer owner = MockBukkit.getMock().addPlayer("Notch");
+        ItemStack stack = new ItemBuilder().setPlayerHead(owner.getUniqueId()).build();
+
+        assertThat(stack.getType()).isEqualTo(Material.PLAYER_HEAD);
+        // MockBukkit's SkullMeta only round-trips the owner's name (it re-derives an offline UUID on
+        // read), so the identity is asserted by name; what matters here is that an owner survives at all.
+        OfflinePlayer applied = ((SkullMeta) stack.getItemMeta()).getOwningPlayer();
+        assertThat(applied).isNotNull();
+        assertThat(applied.getName()).isEqualTo("Notch");
     }
 
     @Test


### PR DESCRIPTION
Two `ItemBuilder` regressions in 1.3.4.

**1. `nexo:` materials fall back to stone.** `setMaterial(String)` exempts only the `itemsadder:` prefix from enum normalisation. A `nexo:<id>` string longer than 11 chars is not a `Material`, so the field is left `null` and `build()` hits its `STONE` fail-safe — the `nexo:` branch that `build()` already implements is never reached. Any Nexo id longer than 6 chars is affected. Fixed by exempting the `nexo:` prefix as well.

**2. Player heads lose their owner.** `setPlayerSkin()` stores the owner on an internal `SkullMeta` field that `build()` never reads (`build()` derives its own `ItemMeta` from the stack), so every head built via `setPlayerHead()` comes out ownerless. Fixed by copying the owner onto the final meta when the built item really is a skull.

No API or signature change: both are existing public methods that simply stopped working as documented.

Covered by two MockBukkit regression tests; `mvnw test` on `bukkit,tests` is 67/67 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)