### PR TITLE
feat: display API + ServerAPI (clean, tested) — supersedes #22

### DIFF
--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayActionExecutor.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayActionExecutor.java
@@ -1,0 +1,75 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+import java.util.Map;
+
+/**
+ * Executes the common display actions used by Novaverse-style YAML modules.
+ */
+public final class DisplayActionExecutor {
+
+    private final DisplayRenderer renderer;
+
+    public DisplayActionExecutor(DisplayRenderer renderer) {
+        this.renderer = renderer;
+    }
+
+    public void execute(Player player, ConfigurationSection actions) {
+        execute(player, actions, Map.of());
+    }
+
+    public void execute(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        if (player == null || !player.isOnline() || actions == null) {
+            return;
+        }
+        sendMessage(player, actions, placeholders);
+        sendActionBar(player, actions, placeholders);
+        sendTitle(player, actions, placeholders);
+        sendBossBar(player, actions, placeholders);
+    }
+
+    private void sendMessage(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        String message = actions.getString("message");
+        if (message == null || message.isEmpty()) {
+            return;
+        }
+        DisplayMessageSpec spec = DisplayMessageSpec.builder()
+                .type(DisplayType.CHAT)
+                .message(message)
+                .build();
+        renderer.send(player, spec, placeholders);
+    }
+
+    private void sendActionBar(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        String message = actions.getString("action-bar", actions.getString("actionbar"));
+        if (message == null || message.isEmpty()) {
+            return;
+        }
+        DisplayMessageSpec spec = DisplayMessageSpec.builder()
+                .type(DisplayType.ACTION_BAR)
+                .message(message)
+                .build();
+        renderer.send(player, spec, placeholders);
+    }
+
+    private void sendTitle(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        ConfigurationSection section = actions.getConfigurationSection("title");
+        if (section == null) {
+            return;
+        }
+        renderer.send(player, DisplayMessageSpec.from(section, DisplayType.TITLE), placeholders);
+    }
+
+    private void sendBossBar(Player player, ConfigurationSection actions, Map<String, ?> placeholders) {
+        ConfigurationSection section = actions.getConfigurationSection("boss-bar");
+        if (section == null) {
+            section = actions.getConfigurationSection("bossbar");
+        }
+        if (section == null) {
+            return;
+        }
+        renderer.send(player, DisplayMessageSpec.from(section, DisplayType.BOSS_BAR), placeholders);
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayMessageSpec.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayMessageSpec.java
@@ -1,0 +1,225 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.Locale;
+
+public final class DisplayMessageSpec {
+
+    private final boolean enabled;
+    private final DisplayType type;
+    private final String message;
+    private final String title;
+    private final String subtitle;
+    private final int fadeInTicks;
+    private final int stayTicks;
+    private final int fadeOutTicks;
+    private final BarColor barColor;
+    private final BarStyle barStyle;
+    private final long durationTicks;
+    private final double progress;
+
+    private DisplayMessageSpec(Builder builder) {
+        this.enabled = builder.enabled;
+        this.type = builder.type;
+        this.message = builder.message;
+        this.title = builder.title;
+        this.subtitle = builder.subtitle;
+        this.fadeInTicks = builder.fadeInTicks;
+        this.stayTicks = builder.stayTicks;
+        this.fadeOutTicks = builder.fadeOutTicks;
+        this.barColor = builder.barColor;
+        this.barStyle = builder.barStyle;
+        this.durationTicks = builder.durationTicks;
+        this.progress = clampProgress(builder.progress);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static DisplayMessageSpec from(ConfigurationSection section) {
+        return from(section, DisplayType.CHAT);
+    }
+
+    public static DisplayMessageSpec from(ConfigurationSection section, DisplayType fallbackType) {
+        Builder builder = builder();
+        if (section == null) {
+            return builder.enabled(false).type(fallbackType).build();
+        }
+
+        builder.enabled(section.getBoolean("enabled", true));
+        builder.type(DisplayType.parse(section.getString("type"), fallbackType));
+        builder.message(section.getString("message", section.getString("text", "")));
+        builder.title(section.getString("title", ""));
+        builder.subtitle(section.getString("subtitle", ""));
+        builder.fadeInTicks(Math.max(0, section.getInt("fade-in", section.getInt("fadeIn", 10))));
+        builder.stayTicks(Math.max(0, section.getInt("stay", 40)));
+        builder.fadeOutTicks(Math.max(0, section.getInt("fade-out", section.getInt("fadeOut", 10))));
+        builder.barColor(enumValue(BarColor.class, section.getString("color"), BarColor.WHITE));
+        builder.barStyle(enumValue(BarStyle.class, section.getString("style"), BarStyle.SOLID));
+        builder.durationTicks(readDurationTicks(section));
+        builder.progress(section.getDouble("progress", 1.0D));
+        return builder.build();
+    }
+
+    public boolean enabled() {
+        return enabled;
+    }
+
+    public DisplayType type() {
+        return type;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public String subtitle() {
+        return subtitle;
+    }
+
+    public int fadeInTicks() {
+        return fadeInTicks;
+    }
+
+    public int stayTicks() {
+        return stayTicks;
+    }
+
+    public int fadeOutTicks() {
+        return fadeOutTicks;
+    }
+
+    public BarColor barColor() {
+        return barColor;
+    }
+
+    public BarStyle barStyle() {
+        return barStyle;
+    }
+
+    public long durationTicks() {
+        return durationTicks;
+    }
+
+    public double progress() {
+        return progress;
+    }
+
+    private static long readDurationTicks(ConfigurationSection section) {
+        if (section.contains("duration-ticks")) {
+            return Math.max(0L, section.getLong("duration-ticks"));
+        }
+        if (section.contains("durationTicks")) {
+            return Math.max(0L, section.getLong("durationTicks"));
+        }
+        if (section.contains("duration")) {
+            return Math.max(0L, section.getLong("duration")) * 20L;
+        }
+        if (section.contains("duration-seconds")) {
+            return Math.max(0L, section.getLong("duration-seconds")) * 20L;
+        }
+        return 0L;
+    }
+
+    private static double clampProgress(double progress) {
+        return Math.max(0.0D, Math.min(1.0D, progress));
+    }
+
+    private static <T extends Enum<T>> T enumValue(Class<T> type, String raw, T fallback) {
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Enum.valueOf(type, raw.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return fallback;
+        }
+    }
+
+    public static final class Builder {
+        private boolean enabled = true;
+        private DisplayType type = DisplayType.CHAT;
+        private String message = "";
+        private String title = "";
+        private String subtitle = "";
+        private int fadeInTicks = 10;
+        private int stayTicks = 40;
+        private int fadeOutTicks = 10;
+        private BarColor barColor = BarColor.WHITE;
+        private BarStyle barStyle = BarStyle.SOLID;
+        private long durationTicks;
+        private double progress = 1.0D;
+
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder type(DisplayType type) {
+            this.type = type == null ? DisplayType.CHAT : type;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message == null ? "" : message;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title == null ? "" : title;
+            return this;
+        }
+
+        public Builder subtitle(String subtitle) {
+            this.subtitle = subtitle == null ? "" : subtitle;
+            return this;
+        }
+
+        public Builder fadeInTicks(int fadeInTicks) {
+            this.fadeInTicks = Math.max(0, fadeInTicks);
+            return this;
+        }
+
+        public Builder stayTicks(int stayTicks) {
+            this.stayTicks = Math.max(0, stayTicks);
+            return this;
+        }
+
+        public Builder fadeOutTicks(int fadeOutTicks) {
+            this.fadeOutTicks = Math.max(0, fadeOutTicks);
+            return this;
+        }
+
+        public Builder barColor(BarColor barColor) {
+            this.barColor = barColor == null ? BarColor.WHITE : barColor;
+            return this;
+        }
+
+        public Builder barStyle(BarStyle barStyle) {
+            this.barStyle = barStyle == null ? BarStyle.SOLID : barStyle;
+            return this;
+        }
+
+        public Builder durationTicks(long durationTicks) {
+            this.durationTicks = Math.max(0L, durationTicks);
+            return this;
+        }
+
+        public Builder progress(double progress) {
+            this.progress = progress;
+            return this;
+        }
+
+        public DisplayMessageSpec build() {
+            return new DisplayMessageSpec(this);
+        }
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayPlaceholders.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayPlaceholders.java
@@ -1,0 +1,32 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import java.util.Map;
+
+public final class DisplayPlaceholders {
+
+    private DisplayPlaceholders() {
+    }
+
+    public static String apply(String input, Map<String, ?> placeholders) {
+        if (input == null || input.isEmpty() || placeholders == null || placeholders.isEmpty()) {
+            return input == null ? "" : input;
+        }
+        String result = input;
+        for (Map.Entry<String, ?> entry : placeholders.entrySet()) {
+            String key = entry.getKey();
+            if (key == null || key.isEmpty()) {
+                continue;
+            }
+            String value = String.valueOf(entry.getValue());
+            result = result.replace(token(key), value);
+        }
+        return result;
+    }
+
+    private static String token(String key) {
+        if (key.startsWith("%") && key.endsWith("%")) {
+            return key;
+        }
+        return "%" + key + "%";
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayRenderer.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayRenderer.java
@@ -1,0 +1,112 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import it.mycraft.powerlib.bukkit.PowerLib;
+import it.mycraft.powerlib.common.utils.ColorAPI;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.boss.BossBar;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import net.kyori.adventure.text.Component;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public final class DisplayRenderer {
+
+    private final Plugin plugin;
+
+    public DisplayRenderer(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void send(Player player, DisplayMessageSpec spec) {
+        send(player, spec, Collections.emptyMap());
+    }
+
+    public void send(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        if (player == null || !player.isOnline() || spec == null || !spec.enabled()) {
+            return;
+        }
+        switch (spec.type()) {
+            case CHAT -> sendChat(player, spec, placeholders);
+            case ACTION_BAR -> sendActionBar(player, spec, placeholders);
+            case TITLE -> sendTitle(player, spec, placeholders);
+            case BOSS_BAR -> sendTemporaryBossBar(player, spec, placeholders);
+        }
+    }
+
+    public void send(Collection<? extends Player> players, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        if (players == null || players.isEmpty()) {
+            return;
+        }
+        for (Player player : players) {
+            send(player, spec, placeholders);
+        }
+    }
+
+
+    private void sendActionBar(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        String message = format(spec.message(), placeholders);
+        if (message.isEmpty()) {
+            return;
+        }
+        try {
+            PowerLib.adventure().player(player).sendActionBar(Component.text(message));
+        } catch (IllegalStateException ignored) {
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(message));
+        }
+    }
+
+    private void sendChat(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        String message = format(spec.message(), placeholders);
+        if (!message.isEmpty()) {
+            player.sendMessage(message);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private void sendTitle(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        player.sendTitle(
+                format(spec.title(), placeholders),
+                format(spec.subtitle(), placeholders),
+                spec.fadeInTicks(),
+                spec.stayTicks(),
+                spec.fadeOutTicks()
+        );
+    }
+
+    private void sendTemporaryBossBar(Player player, DisplayMessageSpec spec, Map<String, ?> placeholders) {
+        String title = format(bossBarTitle(spec), placeholders);
+        if (title.isEmpty()) {
+            return;
+        }
+        BossBar bossBar = Bukkit.createBossBar(title, spec.barColor(), spec.barStyle());
+        bossBar.setProgress(spec.progress());
+        bossBar.addPlayer(player);
+        bossBar.setVisible(true);
+
+        if (plugin == null || !plugin.isEnabled()) {
+            bossBar.removePlayer(player);
+            bossBar.removeAll();
+            bossBar.setVisible(false);
+            return;
+        }
+        long durationTicks = spec.durationTicks() > 0L ? spec.durationTicks() : 200L;
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            bossBar.removePlayer(player);
+            bossBar.removeAll();
+            bossBar.setVisible(false);
+        }, durationTicks);
+    }
+
+    static String format(String raw, Map<String, ?> placeholders) {
+        return ColorAPI.color(DisplayPlaceholders.apply(raw, placeholders));
+    }
+
+    static String bossBarTitle(DisplayMessageSpec spec) {
+        return spec.title().isEmpty() ? spec.message() : spec.title();
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayType.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/DisplayType.java
@@ -1,0 +1,30 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import java.util.Locale;
+
+public enum DisplayType {
+    CHAT,
+    ACTION_BAR,
+    TITLE,
+    BOSS_BAR;
+
+    public static DisplayType parse(String raw, DisplayType fallback) {
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+        String normalized = raw.trim()
+                .toUpperCase(Locale.ROOT)
+                .replace('-', '_')
+                .replace(' ', '_');
+        if ("ACTIONBAR".equals(normalized)) {
+            normalized = "ACTION_BAR";
+        } else if ("BOSSBAR".equals(normalized)) {
+            normalized = "BOSS_BAR";
+        }
+        try {
+            return DisplayType.valueOf(normalized);
+        } catch (IllegalArgumentException ignored) {
+            return fallback;
+        }
+    }
+}

--- a/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/ManagedBossBarService.java
+++ b/bukkit/src/main/java/it/mycraft/powerlib/bukkit/display/ManagedBossBarService.java
@@ -1,0 +1,152 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import org.bukkit.Bukkit;
+import org.bukkit.boss.BossBar;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+public final class ManagedBossBarService implements Listener, AutoCloseable {
+
+    private final Plugin plugin;
+    private final Map<String, ActiveBossBar> bars = new HashMap<>();
+
+    public ManagedBossBarService(Plugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    public void show(String id, Player player, DisplayMessageSpec spec, Map<String, ?> placeholders, double progress) {
+        if (player == null) {
+            hide(id);
+            return;
+        }
+        show(id, java.util.List.of(player), spec, placeholders, progress);
+    }
+
+    public void show(String id, Collection<? extends Player> audience,
+                     DisplayMessageSpec spec, Map<String, ?> placeholders, double progress) {
+        if (id == null || id.isBlank() || spec == null || !spec.enabled()) {
+            return;
+        }
+        if (audience == null || audience.isEmpty()) {
+            hide(id);
+            return;
+        }
+
+        String title = DisplayRenderer.format(DisplayRenderer.bossBarTitle(spec), placeholders);
+        if (title.isEmpty()) {
+            hide(id);
+            return;
+        }
+
+        ActiveBossBar active = bars.computeIfAbsent(id, ignored -> new ActiveBossBar());
+        BossBar bar = active.bar;
+        if (bar == null) {
+            bar = Bukkit.createBossBar(title, spec.barColor(), spec.barStyle());
+            active.bar = bar;
+        }
+
+        bar.setTitle(title);
+        bar.setColor(spec.barColor());
+        bar.setStyle(spec.barStyle());
+        bar.setProgress(Math.max(0.0D, Math.min(1.0D, progress)));
+        syncAudience(bar, audience);
+        bar.setVisible(!bar.getPlayers().isEmpty());
+        scheduleExpiry(id, active, spec.durationTicks());
+    }
+
+    public void hide(String id) {
+        ActiveBossBar active = bars.remove(id);
+        if (active == null) {
+            return;
+        }
+        active.cancelExpiry();
+        active.removeBar();
+    }
+
+    public void clear() {
+        for (ActiveBossBar active : bars.values()) {
+            active.cancelExpiry();
+            active.removeBar();
+        }
+        bars.clear();
+    }
+
+    @Override
+    public void close() {
+        clear();
+        HandlerList.unregisterAll(this);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        for (ActiveBossBar active : bars.values()) {
+            if (active.bar != null) {
+                active.bar.removePlayer(event.getPlayer());
+                active.bar.setVisible(!active.bar.getPlayers().isEmpty());
+            }
+        }
+    }
+
+    private void syncAudience(BossBar bar, Collection<? extends Player> audience) {
+        Set<UUID> wanted = new HashSet<>();
+        for (Player player : audience) {
+            if (player != null && player.isOnline()) {
+                wanted.add(player.getUniqueId());
+            }
+        }
+
+        for (Player current : new ArrayList<>(bar.getPlayers())) {
+            if (!wanted.contains(current.getUniqueId())) {
+                bar.removePlayer(current);
+            }
+        }
+        for (Player player : audience) {
+            if (player != null && player.isOnline()) {
+                bar.addPlayer(player);
+            }
+        }
+    }
+
+    private void scheduleExpiry(String id, ActiveBossBar active, long durationTicks) {
+        active.cancelExpiry();
+        if (durationTicks <= 0L || !plugin.isEnabled()) {
+            return;
+        }
+        active.expiryTask = Bukkit.getScheduler().runTaskLater(plugin, () -> hide(id), durationTicks);
+    }
+
+    private static final class ActiveBossBar {
+        private BossBar bar;
+        private BukkitTask expiryTask;
+
+        private void cancelExpiry() {
+            if (expiryTask != null) {
+                expiryTask.cancel();
+                expiryTask = null;
+            }
+        }
+
+        private void removeBar() {
+            if (bar != null) {
+                bar.removeAll();
+                bar.setVisible(false);
+                bar = null;
+            }
+        }
+    }
+}

--- a/common/src/main/java/it/mycraft/powerlib/common/utils/ServerAPI.java
+++ b/common/src/main/java/it/mycraft/powerlib/common/utils/ServerAPI.java
@@ -1,15 +1,16 @@
 package it.mycraft.powerlib.common.utils;
 
-import lombok.Getter;
-
 /**
  * Detects the running server platform by probing for platform-specific classes. The detected
  * {@link ServerType} is resolved once at class-load time and exposed via {@code getType()}.
  */
 public class ServerAPI {
 
-    @Getter
     private static ServerType type;
+
+    public static ServerType getType() {
+        return type;
+    }
 
     static {
         loadType();

--- a/tests/src/test/java/it/mycraft/powerlib/bukkit/display/DisplayApiTest.java
+++ b/tests/src/test/java/it/mycraft/powerlib/bukkit/display/DisplayApiTest.java
@@ -1,0 +1,229 @@
+package it.mycraft.powerlib.bukkit.display;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.MockPlugin;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.MemoryConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class DisplayApiTest {
+
+    private ServerMock server;
+    private MockPlugin plugin;
+    private PlayerMock player;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.createMockPlugin();
+        player = server.addPlayer();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    // --- DisplayType.parse ---
+
+    @Test
+    void parseHandlesAliasesAndFallback() {
+        assertThat(DisplayType.parse("action-bar", DisplayType.CHAT)).isEqualTo(DisplayType.ACTION_BAR);
+        assertThat(DisplayType.parse("actionbar", DisplayType.CHAT)).isEqualTo(DisplayType.ACTION_BAR);
+        assertThat(DisplayType.parse("boss-bar", DisplayType.CHAT)).isEqualTo(DisplayType.BOSS_BAR);
+        assertThat(DisplayType.parse("bossbar", DisplayType.CHAT)).isEqualTo(DisplayType.BOSS_BAR);
+        assertThat(DisplayType.parse("TiTlE", DisplayType.CHAT)).isEqualTo(DisplayType.TITLE);
+        assertThat(DisplayType.parse(null, DisplayType.TITLE)).isEqualTo(DisplayType.TITLE);
+        assertThat(DisplayType.parse("   ", DisplayType.TITLE)).isEqualTo(DisplayType.TITLE);
+        assertThat(DisplayType.parse("nonsense", DisplayType.CHAT)).isEqualTo(DisplayType.CHAT);
+    }
+
+    // --- DisplayMessageSpec.from ---
+
+    @Test
+    void fromNullSectionIsDisabledWithFallbackType() {
+        DisplayMessageSpec spec = DisplayMessageSpec.from(null, DisplayType.BOSS_BAR);
+        assertThat(spec.enabled()).isFalse();
+        assertThat(spec.type()).isEqualTo(DisplayType.BOSS_BAR);
+    }
+
+    @Test
+    void fromParsesTypeAliasAndMessageTextFallback() {
+        MemoryConfiguration section = new MemoryConfiguration();
+        section.set("type", "action-bar");
+        section.set("text", "hello");
+
+        DisplayMessageSpec spec = DisplayMessageSpec.from(section, DisplayType.CHAT);
+        assertThat(spec.type()).isEqualTo(DisplayType.ACTION_BAR);
+        assertThat(spec.message()).isEqualTo("hello");
+    }
+
+    @Test
+    void fromReadsFadeInAliasAndDurationConversions() {
+        MemoryConfiguration camelCase = new MemoryConfiguration();
+        camelCase.set("fadeIn", 7);
+        camelCase.set("duration", 5); // seconds -> 100 ticks
+        DisplayMessageSpec spec = DisplayMessageSpec.from(camelCase, DisplayType.TITLE);
+        assertThat(spec.fadeInTicks()).isEqualTo(7);
+        assertThat(spec.durationTicks()).isEqualTo(100L);
+
+        MemoryConfiguration seconds = new MemoryConfiguration();
+        seconds.set("duration-seconds", 3);
+        assertThat(DisplayMessageSpec.from(seconds, DisplayType.TITLE).durationTicks()).isEqualTo(60L);
+
+        MemoryConfiguration ticks = new MemoryConfiguration();
+        ticks.set("duration-ticks", 42);
+        assertThat(DisplayMessageSpec.from(ticks, DisplayType.TITLE).durationTicks()).isEqualTo(42L);
+    }
+
+    @Test
+    void fromClampsProgressAndFallsBackOnInvalidEnums() {
+        MemoryConfiguration high = new MemoryConfiguration();
+        high.set("progress", 2.5D);
+        high.set("color", "NOT_A_COLOR");
+        high.set("style", "NOPE");
+        DisplayMessageSpec clampedHigh = DisplayMessageSpec.from(high, DisplayType.BOSS_BAR);
+        assertThat(clampedHigh.progress()).isEqualTo(1.0D);
+        assertThat(clampedHigh.barColor()).isEqualTo(BarColor.WHITE);
+        assertThat(clampedHigh.barStyle()).isEqualTo(BarStyle.SOLID);
+
+        MemoryConfiguration low = new MemoryConfiguration();
+        low.set("progress", -3.0D);
+        low.set("color", "red");
+        low.set("style", "segmented_10");
+        DisplayMessageSpec clampedLow = DisplayMessageSpec.from(low, DisplayType.BOSS_BAR);
+        assertThat(clampedLow.progress()).isEqualTo(0.0D);
+        assertThat(clampedLow.barColor()).isEqualTo(BarColor.RED);
+        assertThat(clampedLow.barStyle()).isEqualTo(BarStyle.SEGMENTED_10);
+    }
+
+    // --- DisplayPlaceholders.apply ---
+
+    @Test
+    void placeholdersApplyCoversTokenFormsAndGuards() {
+        assertThat(DisplayPlaceholders.apply(null, Map.of("a", "b"))).isEmpty();
+        assertThat(DisplayPlaceholders.apply("", Map.of("a", "b"))).isEmpty();
+        assertThat(DisplayPlaceholders.apply("x", null)).isEqualTo("x");
+        assertThat(DisplayPlaceholders.apply("x", Map.of())).isEqualTo("x");
+        assertThat(DisplayPlaceholders.apply("hi %name%", Map.of("name", "Bob"))).isEqualTo("hi Bob");
+        assertThat(DisplayPlaceholders.apply("hi %name%", Map.of("%name%", "Bob"))).isEqualTo("hi Bob");
+
+        Map<String, Object> mixed = new HashMap<>();
+        mixed.put(null, "skip");
+        mixed.put("", "skip");
+        mixed.put("name", null);
+        assertThat(DisplayPlaceholders.apply("hi %name%", mixed)).isEqualTo("hi null");
+    }
+
+    // --- DisplayRenderer ---
+
+    @Test
+    void rendererSendsEachDisplayType() {
+        DisplayRenderer renderer = new DisplayRenderer(plugin);
+
+        renderer.send(player, DisplayMessageSpec.builder().type(DisplayType.CHAT).message("hello").build());
+        assertThat(player.nextMessage()).isEqualTo("hello");
+
+        assertThatCode(() -> {
+            renderer.send(player, DisplayMessageSpec.builder().type(DisplayType.ACTION_BAR).message("act").build());
+            renderer.send(player, DisplayMessageSpec.builder().type(DisplayType.TITLE).title("T").subtitle("S").build());
+            renderer.send(player, DisplayMessageSpec.builder().type(DisplayType.BOSS_BAR).message("B").build());
+            renderer.send(List.of(player), DisplayMessageSpec.builder().type(DisplayType.CHAT).message("group").build(), Map.of());
+            server.getScheduler().performTicks(210L); // run the temporary boss-bar removal task
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rendererIgnoresDisabledNullAndEmpty() {
+        DisplayRenderer renderer = new DisplayRenderer(plugin);
+        renderer.send(null, DisplayMessageSpec.builder().message("x").build());
+        renderer.send(player, DisplayMessageSpec.builder().enabled(false).message("x").build());
+        renderer.send(player, DisplayMessageSpec.builder().type(DisplayType.CHAT).message("").build());
+        renderer.send(List.of(), DisplayMessageSpec.builder().message("x").build(), Map.of());
+        assertThat(player.nextMessage()).isNull();
+    }
+
+    // --- DisplayActionExecutor ---
+
+    @Test
+    void executorRoutesAllConfiguredActions() {
+        MemoryConfiguration actions = new MemoryConfiguration();
+        actions.set("message", "chat-%who%");
+        actions.set("action-bar", "act-%who%");
+        ConfigurationSection title = actions.createSection("title");
+        title.set("title", "Title");
+        title.set("subtitle", "Sub");
+        ConfigurationSection boss = actions.createSection("boss-bar");
+        boss.set("message", "Boss");
+        boss.set("duration", 2);
+
+        DisplayActionExecutor executor = new DisplayActionExecutor(new DisplayRenderer(plugin));
+        executor.execute(player, actions, Map.of("who", "Bob"));
+
+        assertThat(player.nextMessage()).isEqualTo("chat-Bob");
+        assertThatCode(() -> server.getScheduler().performTicks(60L)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void executorHonoursAliasesAndGuards() {
+        DisplayActionExecutor executor = new DisplayActionExecutor(new DisplayRenderer(plugin));
+
+        MemoryConfiguration aliased = new MemoryConfiguration();
+        aliased.set("actionbar", "viaAlias");
+        ConfigurationSection boss = aliased.createSection("bossbar");
+        boss.set("message", "AliasBoss");
+
+        assertThatCode(() -> {
+            executor.execute(player, aliased, Map.of());
+            executor.execute(null, aliased);       // null player -> no-op
+            executor.execute(player, (ConfigurationSection) null); // null actions -> no-op
+            server.getScheduler().performTicks(210L);
+        }).doesNotThrowAnyException();
+    }
+
+    // --- ManagedBossBarService ---
+
+    @Test
+    void managedBossBarServiceShowHideClearDoesNotThrow() {
+        DisplayMessageSpec spec = DisplayMessageSpec.builder().message("Hi").build();
+
+        assertThatCode(() -> {
+            ManagedBossBarService service = new ManagedBossBarService(plugin);
+            service.show("greeting", player, spec, Map.of(), 0.5D);
+            service.hide("greeting");
+            service.show("greeting", player, spec, Map.of(), 0.5D);
+            service.clear();
+            service.close();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void managedBossBarServiceHandlesAudienceExpiryAndGuards() {
+        DisplayMessageSpec timed = DisplayMessageSpec.builder()
+                .message("Timed").durationTicks(40L).build();
+
+        assertThatCode(() -> {
+            ManagedBossBarService service = new ManagedBossBarService(plugin);
+            service.show("t", List.of(player), timed, Map.of(), 0.7D);
+            server.getScheduler().performTicks(45L);          // fires scheduled expiry
+            service.show("t", List.of(), timed, Map.of(), 0.5D); // empty audience -> hide
+            service.show("n", (PlayerMock) null, timed, Map.of(), 0.5D); // null player -> hide
+            service.show("d", List.of(player),
+                    DisplayMessageSpec.builder().enabled(false).message("x").build(), Map.of(), 0.5D); // disabled -> ignored
+            service.close();
+        }).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Supersedes #22.

Keeps the genuinely useful, working parts of #22 and drops the non-functional config API.

## Kept (display primitives + ServerAPI)
- `bukkit/.../display/`: `DisplayType`, `DisplayMessageSpec`, `DisplayRenderer`, `DisplayActionExecutor`, `DisplayPlaceholders`, `ManagedBossBarService` — chat / action-bar / title / boss-bar rendering plus a managed (deduped, auto-expiring, quit-aware) boss-bar service.
- `common/.../utils/ServerAPI`: swaps the Lombok `@Getter` for an explicit `getType()` (behavior-equivalent).
- Credit for the display code: @antoilmalvagio (commit authored to him).

## Removed (safe config update API — non-functional)
Dropped the `createAndUpdate(...)` overloads on `ConfigManager` plus `ConfigUpdateOptions` and `ConfigUpdateResult`. The API advertised backup / atomic write / dry-run / validate, but:
- `createAndUpdate(file, source, ConfigUpdateOptions)` **ignored the options** and just delegated to `create(...)`.
- `ConfigUpdateResult` was **never instantiated or returned** — 100% dead code.

A false contract like that has no place in the keystone lib. If safe config update is wanted later, it should ship with a real implementation and tests.

## Tests
Added `DisplayApiTest` (MockBukkit + JUnit5 + AssertJ):
- `DisplayType.parse` alias/fallback handling.
- `DisplayMessageSpec.from` — type aliases, message/text fallback, `fade-in`/`fadeIn`, `duration`/`duration-seconds`/`duration-ticks` → ticks, progress clamp 0..1, enum fallback on invalid color/style.
- `ManagedBossBarService` show → hide → clear smoke test.

`./mvnw -pl tests -am test` (JDK 17): BUILD SUCCESS, all tests green (DisplayApiTest 6/6).
